### PR TITLE
Honor channel window adjustments

### DIFF
--- a/oxish-proto/src/channels.rs
+++ b/oxish-proto/src/channels.rs
@@ -619,6 +619,48 @@ impl Encode for ChannelEof {
     }
 }
 
+/// `SSH_MSG_CHANNEL_WINDOW_ADJUST` (RFC 4254 section 5.2)
+///
+/// Grows the recipient's send window for the channel by `bytes_to_add`, letting it send that
+/// many more bytes of channel data before it must wait for further adjustments.
+#[derive(Debug)]
+pub struct ChannelWindowAdjust {
+    pub recipient_channel: u32,
+    pub bytes_to_add: u32,
+}
+
+impl<'a> TryFrom<IncomingPacket<'a>> for ChannelWindowAdjust {
+    type Error = ProtoError;
+
+    fn try_from(packet: IncomingPacket<'a>) -> Result<Self, Self::Error> {
+        if packet.message_type != MessageType::ChannelWindowAdjust {
+            return Err(ProtoError::InvalidPacket(
+                "expected channel window adjust packet",
+            ));
+        }
+
+        let Decoded {
+            value: recipient_channel,
+            next,
+        } = u32::decode(packet.payload)?;
+
+        let Decoded {
+            value: bytes_to_add,
+            next,
+        } = u32::decode(next)?;
+
+        match next.is_empty() {
+            true => Ok(Self {
+                recipient_channel,
+                bytes_to_add,
+            }),
+            false => Err(ProtoError::InvalidPacket(
+                "extra data in channel window adjust packet",
+            )),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct ChannelClose {
     pub recipient_channel: u32,
@@ -650,5 +692,45 @@ impl Encode for ChannelClose {
     fn encode(&self, buffer: &mut Vec<u8>) {
         MessageType::ChannelClose.encode(buffer);
         self.recipient_channel.encode(buffer);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn packet(message_type: MessageType, payload: &[u8]) -> IncomingPacket<'_> {
+        IncomingPacket {
+            sequence_number: 0,
+            message_type,
+            payload,
+        }
+    }
+
+    #[test]
+    fn window_adjust_decode() {
+        // recipient channel 1, grow the window by 0x0002_0000 bytes
+        let payload = [0, 0, 0, 1, 0, 2, 0, 0];
+        let adjust =
+            ChannelWindowAdjust::try_from(packet(MessageType::ChannelWindowAdjust, &payload))
+                .unwrap();
+        assert_eq!(adjust.recipient_channel, 1);
+        assert_eq!(adjust.bytes_to_add, 0x0002_0000);
+    }
+
+    #[test]
+    fn window_adjust_rejects_trailing_bytes() {
+        let payload = [0, 0, 0, 1, 0, 0, 0, 1, 0xff];
+        assert_eq!(
+            ChannelWindowAdjust::try_from(packet(MessageType::ChannelWindowAdjust, &payload))
+                .unwrap_err(),
+            ProtoError::InvalidPacket("extra data in channel window adjust packet"),
+        );
+    }
+
+    #[test]
+    fn window_adjust_rejects_wrong_type() {
+        let payload = [0, 0, 0, 1, 0, 0, 0, 1];
+        assert!(ChannelWindowAdjust::try_from(packet(MessageType::ChannelData, &payload)).is_err());
     }
 }

--- a/oxish-proto/src/lib.rs
+++ b/oxish-proto/src/lib.rs
@@ -12,8 +12,8 @@ pub use base::{
 mod channels;
 pub use channels::{
     ChannelClose, ChannelData, ChannelEof, ChannelOpen, ChannelOpenConfirmation,
-    ChannelOpenFailure, ChannelRequest, ChannelRequestSuccess, ChannelRequestType, Env, Mode,
-    PtyReq, WindowChange,
+    ChannelOpenFailure, ChannelRequest, ChannelRequestSuccess, ChannelRequestType,
+    ChannelWindowAdjust, Env, Mode, PtyReq, WindowChange,
 };
 pub mod crypto;
 use crypto::CryptoError;

--- a/oxish/src/connections.rs
+++ b/oxish/src/connections.rs
@@ -13,7 +13,7 @@ use std::{
 use proto::{
     ChannelClose, ChannelData, ChannelEof, ChannelOpen, ChannelOpenConfirmation,
     ChannelOpenFailure, ChannelRequest, ChannelRequestSuccess, ChannelRequestType, ChannelType,
-    Encode, Encoder, IncomingPacket, MessageType, ProtoError, PtyReq,
+    ChannelWindowAdjust, Encode, Encoder, IncomingPacket, MessageType, ProtoError, PtyReq,
 };
 use tracing::{debug, warn};
 
@@ -49,6 +49,7 @@ impl Channels {
         let channel = entry.insert(Channel {
             remote_id: open.sender_channel,
             window_size: open.initial_window_size,
+            send_window: open.initial_window_size,
             maximum_packet_size: open.maximum_packet_size,
             env: Vec::new(),
             terminal: None,
@@ -117,6 +118,26 @@ impl Channels {
             Some(TerminalState::Running(terminal)) => Some((terminal, &data.data)),
             _ => None,
         })
+    }
+
+    pub(crate) fn window_adjust(&mut self, adjust: &ChannelWindowAdjust) -> Result<(), ProtoError> {
+        let Some(channel) = self.channels.get_mut(&adjust.recipient_channel) else {
+            return Err(ProtoError::InvalidPacket(
+                "channel window adjust for unknown channel ID",
+            ));
+        };
+
+        // Saturating rather than wrapping: a peer that overflows our window is misbehaving, but
+        // clamping keeps us from shrinking it (RFC 4254 section 5.2 caps windows at 2^32 - 1).
+        channel.send_window = channel.send_window.saturating_add(adjust.bytes_to_add);
+        debug!(
+            channel_id = %adjust.recipient_channel,
+            added = %adjust.bytes_to_add,
+            window = %channel.send_window,
+            "grew channel send window",
+        );
+
+        Ok(())
     }
 
     pub(crate) fn eof(&mut self, eof: &ChannelEof) -> Result<(), ProtoError> {
@@ -201,8 +222,19 @@ impl<'a> Future for TerminalsFuture<'a> {
                 }
             };
 
+            // Respect the peer's window: never send more than it has room for, nor a single
+            // packet larger than it will accept (RFC 4254 section 5.2). A window-blocked channel
+            // is skipped here and resumes once a window adjust arrives on the receive path.
             let mut buf = [0u8; 4096];
-            match terminal.poll_read(&mut buf, cx) {
+            let limit = channel
+                .send_window
+                .min(channel.maximum_packet_size)
+                .min(buf.len() as u32) as usize;
+            if limit == 0 {
+                continue;
+            }
+
+            match terminal.poll_read(&mut buf[..limit], cx) {
                 Poll::Ready(result @ Ok(0)) | Poll::Ready(result @ Err(_)) => {
                     if let TerminalState::Running(terminal) =
                         mem::replace(state, TerminalState::Closing)
@@ -224,6 +256,8 @@ impl<'a> Future for TerminalsFuture<'a> {
                     });
                 }
                 Poll::Ready(Ok(n)) => {
+                    // `limit` bounded the read to the window, so this cannot underflow.
+                    channel.send_window -= n as u32;
                     return Poll::Ready(Ok(Some(OutgoingChannelMessage::Data(ChannelData {
                         recipient_channel: channel.remote_id,
                         data: Cow::Owned(buf[..n].to_vec()),
@@ -241,6 +275,11 @@ impl<'a> Future for TerminalsFuture<'a> {
 pub(crate) struct Channel {
     remote_id: u32,
     window_size: u32,
+    /// Bytes we may still send to the peer before it must grow our window
+    ///
+    /// Seeded from the peer's initial window and replenished by
+    /// `SSH_MSG_CHANNEL_WINDOW_ADJUST` (RFC 4254 section 5.2).
+    send_window: u32,
     maximum_packet_size: u32,
     env: Vec<(String, String)>,
     terminal: Option<TerminalState>,
@@ -308,6 +347,7 @@ pub(crate) enum IncomingChannelMessage<'a> {
     Open(ChannelOpen<'a>),
     Request(ChannelRequest<'a>),
     Data(ChannelData<'a>),
+    WindowAdjust(ChannelWindowAdjust),
     Eof(ChannelEof),
     Close(ChannelClose),
 }
@@ -326,6 +366,9 @@ impl<'a> TryFrom<IncomingPacket<'a>> for IncomingChannelMessage<'a> {
             MessageType::ChannelData => {
                 Ok(IncomingChannelMessage::Data(ChannelData::try_from(packet)?))
             }
+            MessageType::ChannelWindowAdjust => Ok(IncomingChannelMessage::WindowAdjust(
+                ChannelWindowAdjust::try_from(packet)?,
+            )),
             MessageType::ChannelEof => {
                 Ok(IncomingChannelMessage::Eof(ChannelEof::try_from(packet)?))
             }

--- a/oxish/src/lib.rs
+++ b/oxish/src/lib.rs
@@ -98,6 +98,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Session<T> {
                             Ok(None) => Ok(()),
                             Err(error) => Err(error.into()),
                         }
+                        IncomingChannelMessage::WindowAdjust(adjust) => self.channels.window_adjust(&adjust).map_err(Into::into),
                         IncomingChannelMessage::Eof(eof) => self.channels.eof(&eof).map_err(Into::into),
                         IncomingChannelMessage::Close(close) => self.channels.close(&close, &mut encoder),
                     };

--- a/oxish/src/tests.rs
+++ b/oxish/src/tests.rs
@@ -20,7 +20,7 @@ async fn handshake_ecdsa_aws_lc() {
     handshake(
         aws_lc::DEFAULT_PROVIDER,
         PublicKeyAlgorithm::EcdsaSha2Nistp256,
-        false,
+        Scenario::default(),
     )
     .await;
 }
@@ -32,7 +32,7 @@ async fn handshake_ecdsa_graviola() {
     handshake(
         graviola::DEFAULT_PROVIDER,
         PublicKeyAlgorithm::EcdsaSha2Nistp256,
-        false,
+        Scenario::default(),
     )
     .await;
 }
@@ -41,7 +41,12 @@ async fn handshake_ecdsa_graviola() {
 #[cfg(feature = "aws-lc")]
 #[tokio::test]
 async fn handshake_ed25519_aws_lc() {
-    handshake(aws_lc::DEFAULT_PROVIDER, PublicKeyAlgorithm::Ed25519, false).await;
+    handshake(
+        aws_lc::DEFAULT_PROVIDER,
+        PublicKeyAlgorithm::Ed25519,
+        Scenario::default(),
+    )
+    .await;
 }
 
 /// Exercise an ssh-ed25519 client key against the graviola provider
@@ -51,7 +56,7 @@ async fn handshake_ed25519_graviola() {
     handshake(
         graviola::DEFAULT_PROVIDER,
         PublicKeyAlgorithm::Ed25519,
-        false,
+        Scenario::default(),
     )
     .await;
 }
@@ -62,16 +67,59 @@ async fn handshake_ecdsa_graviola_split() {
     handshake(
         graviola::DEFAULT_PROVIDER,
         PublicKeyAlgorithm::EcdsaSha2Nistp256,
-        true,
+        Scenario {
+            split: true,
+            ..Scenario::default()
+        },
     )
     .await;
+}
+
+/// Stream more output than a channel window holds, exercising `SSH_MSG_CHANNEL_WINDOW_ADJUST`
+#[cfg(feature = "aws-lc")]
+#[tokio::test]
+async fn bulk_output_aws_lc() {
+    handshake(
+        aws_lc::DEFAULT_PROVIDER,
+        PublicKeyAlgorithm::Ed25519,
+        Scenario {
+            bulk: true,
+            ..Scenario::default()
+        },
+    )
+    .await;
+}
+
+/// The same, across the session subprocess handoff
+#[cfg(feature = "graviola")]
+#[tokio::test]
+async fn bulk_output_graviola_split() {
+    handshake(
+        graviola::DEFAULT_PROVIDER,
+        PublicKeyAlgorithm::Ed25519,
+        Scenario {
+            split: true,
+            bulk: true,
+        },
+    )
+    .await;
+}
+
+/// Knobs for a single [`handshake`] run
+#[derive(Clone, Copy, Default)]
+struct Scenario {
+    /// Hand the authenticated connection off to a session subprocess
+    split: bool,
+    /// Emit far more output than one channel window, forcing repeated window adjustments
+    bulk: bool,
 }
 
 async fn handshake(
     provider: &'static dyn CryptoProvider,
     algorithm: PublicKeyAlgorithm<'_>,
-    split: bool,
+    scenario: Scenario,
 ) {
+    let Scenario { split, bulk } = scenario;
     subscribe();
 
     let dir = TempDir::new().unwrap();
@@ -172,11 +220,23 @@ async fn handshake(
         .spawn()
         .expect("failed to spawn ssh");
 
+    // In the bulk scenario, emit well over a channel window's worth of output (the client
+    // advertises ~1-2 MiB) before the sentinel, so the whole transfer only completes if the
+    // server honors the window adjustments the client sends as it drains the data.
+    let command = match bulk {
+        true => b"seq 1 400000\necho OXISH-$((6*7))\nexit\n".to_vec(),
+        false => COMMAND.to_vec(),
+    };
+
     let mut stdin = child.stdin.take().unwrap();
-    stdin.write_all(COMMAND).await.unwrap();
+    stdin.write_all(&command).await.unwrap();
     drop(stdin); // close stdin so the session ends after `exit`
 
-    let output = timeout(Duration::from_secs(10), child.wait_with_output())
+    let client_timeout = match bulk {
+        true => Duration::from_secs(30),
+        false => Duration::from_secs(10),
+    };
+    let output = timeout(client_timeout, child.wait_with_output())
         .await
         .expect("ssh client timed out")
         .expect("failed to wait for ssh");


### PR DESCRIPTION
The session loop treated `SSH_MSG_CHANNEL_WINDOW_ADJUST` (type 93) as an unexpected channel message and returned an error, which tears the connection down. A client only sends that message once it has drained enough channel data to replenish the server's send window, so any session that streamed more than the initial window's worth of output — a client advertises roughly 1–2 MiB — got killed mid-transfer. (This surfaced while testing client-triggered rekeying in #196: a bulk-output test hit it, more eagerly on macOS OpenSSH, which replenishes the window sooner.)

## What changed

- **`oxish-proto`**: add a `ChannelWindowAdjust` message (`recipient_channel`, `bytes_to_add`) with a decoder, per RFC 4254 §5.2.
- **`oxish`**: track a per-channel `send_window`, seeded from the peer's `initial_window_size` and grown by each window adjustment. The terminal read is now bounded by `min(send_window, maximum_packet_size, buf)`, and a window-blocked channel is skipped until an adjustment arrives — at which point the existing `select!` loop re-polls and resumes it (the incoming packet is what wakes the task, so there's no lost wakeup). The send window is decremented as data is emitted.

Only the send direction (server → client flow control) is addressed here — that's what the client's window adjustments govern. The server still advertises a fixed receive window and does not yet send its own adjustments; a very large client → server transfer would stall, but that's a separate gap from the crash fixed here.

## Tests

- Proto decode tests for `ChannelWindowAdjust` (valid frame, trailing-byte rejection, wrong message type).
- End-to-end `bulk_output_*` tests that stream ~2.6 MiB before a sentinel, in both the in-process and subprocess-handoff configurations. The sentinel only arrives if the transfer survived the window adjustments; on `main` these fail (the connection dies mid-stream), and they pass with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjnnUPsuUtNyD3mbuXHapA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjnnUPsuUtNyD3mbuXHapA)_