### PR TITLE
Change `--generate-host-key` to produce OpenSSH format 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,6 +549,7 @@ version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
  "oxish-proto",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,7 @@ version = "0.2.0"
 dependencies = [
  "aws-lc-rs",
  "oxish-proto",
+ "zeroize",
 ]
 
 [[package]]

--- a/oxish-aws-lc/Cargo.toml
+++ b/oxish-aws-lc/Cargo.toml
@@ -17,6 +17,7 @@ fips = ["aws-lc-rs/fips"]
 [dependencies]
 aws-lc-rs = { workspace = true }
 proto = { package = "oxish-proto", version = "0.1", path = "../oxish-proto" }
+zeroize = { workspace = true }
 
 [lints]
 workspace = true

--- a/oxish-aws-lc/Cargo.toml
+++ b/oxish-aws-lc/Cargo.toml
@@ -17,6 +17,7 @@ fips = ["aws-lc-rs/fips"]
 [dependencies]
 aws-lc-rs = { workspace = true }
 proto = { package = "oxish-proto", version = "0.2", path = "../oxish-proto" }
+zeroize = { workspace = true }
 
 [lints]
 workspace = true

--- a/oxish-aws-lc/src/lib.rs
+++ b/oxish-aws-lc/src/lib.rs
@@ -4,6 +4,7 @@ use ::aws_lc_rs::{
     aead::{AES_128_GCM, Aad, LessSafeKey, NONCE_LEN, Nonce, UnboundKey},
     agreement::{self, EphemeralPrivateKey, X25519},
     digest,
+    encoding::{AsBigEndian, Curve25519SeedBin, EcPrivateKeyBin},
     kem::ML_KEM_768,
     rand,
     signature::{self, EcdsaKeyPair, Ed25519KeyPair, KeyPair, UnparsedPublicKey},
@@ -17,6 +18,7 @@ use proto::{
     },
     named::{EncryptionAlgorithm, KeyExchangeAlgorithm, MacAlgorithm, PublicKeyAlgorithm},
 };
+use zeroize::Zeroizing;
 
 pub const DEFAULT_PROVIDER: &'static dyn CryptoProvider = &Provider;
 
@@ -404,6 +406,13 @@ impl SigningKey for Ed25519SigningKey {
     fn algorithm(&self) -> PublicKeyAlgorithm<'static> {
         PublicKeyAlgorithm::Ed25519
     }
+
+    fn private_key(&self) -> Result<Zeroizing<Vec<u8>>, CryptoError> {
+        let seed = self.key_pair.seed().map_err(|_| CryptoError::Unspecified)?;
+        let bytes = AsBigEndian::<Curve25519SeedBin<'_>>::as_be_bytes(&seed)
+            .map_err(|_| CryptoError::Unspecified)?;
+        Ok(Zeroizing::new(bytes.as_ref().to_vec()))
+    }
 }
 
 struct EcdsaP256SigningKey {
@@ -438,6 +447,12 @@ impl SigningKey for EcdsaP256SigningKey {
 
     fn algorithm(&self) -> PublicKeyAlgorithm<'static> {
         PublicKeyAlgorithm::EcdsaSha2Nistp256
+    }
+
+    fn private_key(&self) -> Result<Zeroizing<Vec<u8>>, CryptoError> {
+        let d = AsBigEndian::<EcPrivateKeyBin<'_>>::as_be_bytes(&self.key_pair.private_key())
+            .map_err(|_| CryptoError::Unspecified)?;
+        Ok(Zeroizing::new(d.as_ref().to_vec()))
     }
 }
 

--- a/oxish-aws-lc/src/lib.rs
+++ b/oxish-aws-lc/src/lib.rs
@@ -4,6 +4,7 @@ use ::aws_lc_rs::{
     aead::{AES_128_GCM, Aad, LessSafeKey, NONCE_LEN, Nonce, UnboundKey},
     agreement::{self, EphemeralPrivateKey, X25519},
     digest,
+    encoding::{AsBigEndian, Curve25519SeedBin, EcPrivateKeyBin},
     kem::ML_KEM_768,
     rand,
     signature::{self, EcdsaKeyPair, Ed25519KeyPair, KeyPair, UnparsedPublicKey},
@@ -17,6 +18,7 @@ use proto::{
     },
     named::{EncryptionAlgorithm, KeyExchangeAlgorithm, MacAlgorithm, PublicKeyAlgorithm},
 };
+use zeroize::Zeroizing;
 
 pub const DEFAULT_PROVIDER: &'static dyn CryptoProvider = &Provider;
 
@@ -28,33 +30,34 @@ impl CryptoProvider for Provider {
     fn generate_signing_key(
         &self,
         algorithm: &PublicKeyAlgorithm<'_>,
-    ) -> Result<(Box<dyn SigningKey>, Vec<u8>), CryptoError> {
+    ) -> Result<(Box<dyn SigningKey>, Zeroizing<Vec<u8>>), CryptoError> {
         match algorithm {
             PublicKeyAlgorithm::Ed25519 => {
                 let key_pair =
                     Ed25519KeyPair::generate().map_err(|_| CryptoError::KeyGenerationFailed)?;
 
-                let pkcs8 = key_pair
-                    .to_pkcs8v1()
-                    .map_err(|_| CryptoError::Unspecified)?
-                    .as_ref()
-                    .to_vec();
+                let seed = key_pair.seed().map_err(|_| CryptoError::KeyNotExportable)?;
+                let be = AsBigEndian::<Curve25519SeedBin<'_>>::as_be_bytes(&seed)
+                    .map_err(|_| CryptoError::KeyNotExportable)?;
 
-                Ok((Box::new(Ed25519SigningKey::new(key_pair)), pkcs8))
+                Ok((
+                    Box::new(Ed25519SigningKey::new(key_pair)),
+                    Zeroizing::new(be.as_ref().to_vec()),
+                ))
             }
             PublicKeyAlgorithm::EcdsaSha2Nistp256 => {
                 let key_pair = EcdsaKeyPair::generate(&signature::ECDSA_P256_SHA256_FIXED_SIGNING)
                     .map_err(|_| CryptoError::KeyGenerationFailed)?;
 
-                let pkcs8 = key_pair
-                    .to_pkcs8v1()
-                    .map_err(|_| CryptoError::Unspecified)?
-                    .as_ref()
-                    .to_vec();
+                let d = AsBigEndian::<EcPrivateKeyBin<'_>>::as_be_bytes(&key_pair.private_key())
+                    .map_err(|_| CryptoError::KeyNotExportable)?;
 
-                Ok((Box::new(EcdsaP256SigningKey::new(key_pair)), pkcs8))
+                Ok((
+                    Box::new(EcdsaP256SigningKey::new(key_pair)),
+                    Zeroizing::new(d.as_ref().to_vec()),
+                ))
             }
-            _ => Err(CryptoError::UnknownAlgorithm),
+            PublicKeyAlgorithm::Unknown(_) => Err(CryptoError::UnknownAlgorithm),
         }
     }
 

--- a/oxish-graviola/src/lib.rs
+++ b/oxish-graviola/src/lib.rs
@@ -385,6 +385,12 @@ impl SigningKey for Ed25519Key {
     fn algorithm(&self) -> PublicKeyAlgorithm<'static> {
         PublicKeyAlgorithm::Ed25519
     }
+
+    fn private_key(&self) -> Result<Zeroizing<Vec<u8>>, CryptoError> {
+        // as_seed() returns an owned copy, so wrap it too
+        let seed = Zeroizing::new(self.key.as_seed());
+        Ok(Zeroizing::new(seed.to_vec()))
+    }
 }
 
 struct EcdsaP256Key {
@@ -417,6 +423,12 @@ impl SigningKey for EcdsaP256Key {
 
     fn algorithm(&self) -> PublicKeyAlgorithm<'static> {
         PublicKeyAlgorithm::EcdsaSha2Nistp256
+    }
+
+    fn private_key(&self) -> Result<Zeroizing<Vec<u8>>, CryptoError> {
+        // as_bytes() returns an owned copy, so wrap it too
+        let d = Zeroizing::new(self.key.private_key.as_bytes());
+        Ok(Zeroizing::new(d.to_vec()))
     }
 }
 

--- a/oxish-graviola/src/lib.rs
+++ b/oxish-graviola/src/lib.rs
@@ -30,38 +30,30 @@ impl CryptoProvider for Provider {
     fn generate_signing_key(
         &self,
         algorithm: &PublicKeyAlgorithm<'_>,
-    ) -> Result<(Box<dyn SigningKey>, Vec<u8>), CryptoError> {
+    ) -> Result<(Box<dyn SigningKey>, Zeroizing<Vec<u8>>), CryptoError> {
         match algorithm {
             PublicKeyAlgorithm::Ed25519 => {
                 let key =
                     Ed25519SigningKey::generate().map_err(|_| CryptoError::KeyGenerationFailed)?;
 
-                // An Ed25519 PKCS#8 v2 document (with the embedded public key) is
-                // well under 128 bytes.
-                let mut buf = Zeroizing::new([0u8; 128]);
-                let pkcs8 = key
-                    .to_pkcs8_der(&mut *buf)
-                    .map_err(|_| CryptoError::Unspecified)?
-                    .to_vec();
-
-                Ok((Box::new(Ed25519Key::new(key)), pkcs8))
+                // as_seed() returns an owned copy, so wrap it too
+                let seed = Zeroizing::new(key.as_seed());
+                Ok((
+                    Box::new(Ed25519Key::new(key)),
+                    Zeroizing::new(seed.to_vec()),
+                ))
             }
             PublicKeyAlgorithm::EcdsaSha2Nistp256 => {
                 let private_key =
                     StaticPrivateKey::new_random().map_err(|_| CryptoError::KeyGenerationFailed)?;
+
+                // as_bytes() returns an owned copy too
+                let d = Zeroizing::new(private_key.as_bytes());
                 let key = ecdsa::SigningKey::<P256> { private_key };
 
-                // A P-256 PKCS#8 v1 document (with the embedded public key) is
-                // comfortably under 256 bytes.
-                let mut buf = [0u8; 256];
-                let pkcs8 = key
-                    .to_pkcs8_der(&mut buf)
-                    .map_err(|_| CryptoError::Unspecified)?
-                    .to_vec();
-
-                Ok((Box::new(EcdsaP256Key::new(key)), pkcs8))
+                Ok((Box::new(EcdsaP256Key::new(key)), Zeroizing::new(d.to_vec())))
             }
-            _ => Err(CryptoError::UnknownAlgorithm),
+            PublicKeyAlgorithm::Unknown(_) => Err(CryptoError::UnknownAlgorithm),
         }
     }
 

--- a/oxish-proto/src/crypto.rs
+++ b/oxish-proto/src/crypto.rs
@@ -1,7 +1,7 @@
 use core::{error::Error as StdError, fmt};
 use std::sync::Arc;
 
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::named::{EncryptionAlgorithm, KeyExchangeAlgorithm, MacAlgorithm, PublicKeyAlgorithm};
 
@@ -425,6 +425,17 @@ pub trait SigningKey: Send + Sync {
 
     /// The public key algorithm of this key
     fn algorithm(&self) -> PublicKeyAlgorithm<'static>;
+
+    /// The private key material, in the form the key is stored in
+    ///
+    /// For Ed25519 this is the 32-byte seed, not the derived signing
+    /// scalar. For ECDSA, it is the scalar `d` as a big-endian
+    /// fixed-length integer.
+    ///
+    /// Returns `Err` for keys held in hardware or by an agent.
+    fn private_key(&self) -> Result<Zeroizing<Vec<u8>>, CryptoError> {
+        Err(CryptoError::Unspecified)
+    }
 }
 
 /// A public key that can verify signatures

--- a/oxish-proto/src/crypto.rs
+++ b/oxish-proto/src/crypto.rs
@@ -1,7 +1,7 @@
 use core::{error::Error as StdError, fmt};
 use std::sync::Arc;
 
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::named::{EncryptionAlgorithm, KeyExchangeAlgorithm, MacAlgorithm, PublicKeyAlgorithm};
 
@@ -9,12 +9,12 @@ use crate::named::{EncryptionAlgorithm, KeyExchangeAlgorithm, MacAlgorithm, Publ
 pub trait CryptoProvider: Send + Sync {
     /// Generate a fresh signing key
     ///
-    /// Returns the key together with its PKCS#8 serialization, so the caller can
-    /// persist it and load it again later with [`Self::signing_key_from_pkcs8()`].
+    /// Returns the key together with its private key, so the caller can encode it
+    /// to OpenSSH format.
     fn generate_signing_key(
         &self,
         algorithm: &PublicKeyAlgorithm<'_>,
-    ) -> Result<(Box<dyn SigningKey>, Vec<u8>), CryptoError>;
+    ) -> Result<GeneratedKey, CryptoError>;
 
     /// Load a signing key from its PKCS#8 serialization
     fn signing_key_from_pkcs8(&self, pkcs8: &[u8]) -> Result<Box<dyn SigningKey>, CryptoError>;
@@ -61,6 +61,9 @@ pub trait CryptoProvider: Send + Sync {
     /// A source of cryptographically secure random bytes
     fn secure_random(&self) -> &'static dyn SecureRandom;
 }
+
+/// A freshly generated signing key and its private key material
+pub type GeneratedKey = (Box<dyn SigningKey>, Zeroizing<Vec<u8>>);
 
 /// The algorithms supported by a [`CryptoProvider`], in preference order
 ///
@@ -467,6 +470,7 @@ impl From<Vec<u8>> for SharedSecret {
 
 /// An error returned by a cryptographic operation
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum CryptoError {
     /// Decryption or tag verification of a packet failed
     DecryptionFailed,
@@ -478,6 +482,8 @@ pub enum CryptoError {
     KeyAgreementFailed,
     /// Generating a new key pair failed
     KeyGenerationFailed,
+    /// The private key not exportable
+    KeyNotExportable,
     /// Key material was rejected while loading it
     KeyRejected,
     /// The per-key nonce space was exhausted
@@ -500,6 +506,7 @@ impl fmt::Display for CryptoError {
             Self::InvalidLength => write!(f, "invalid length"),
             Self::KeyAgreementFailed => write!(f, "key agreement failed"),
             Self::KeyGenerationFailed => write!(f, "key generation failed"),
+            Self::KeyNotExportable => write!(f, "private key not exportable"),
             Self::KeyRejected => write!(f, "key rejected"),
             Self::NonceOverflow => write!(f, "nonce overflow"),
             Self::NoRandomness => write!(f, "no randomness available"),

--- a/oxish-proto/src/host_keys.rs
+++ b/oxish-proto/src/host_keys.rs
@@ -89,6 +89,14 @@ impl HostKeys {
         Ok(Self(keys))
     }
 
+    /// Create host keys from the contents of a single OpenSSH-format
+    /// private key file
+    ///
+    /// Only supports unencrypted keys for now.
+    pub fn from_openssh_v1(pem: &str, provider: &dyn CryptoProvider) -> Result<Self, ProtoError> {
+        Self::new(OpenSshKeyV1::from_str(pem)?.keys.into_iter(), provider)
+    }
+
     /// Create a new set of host keys from the given PKCS#8 private keys
     ///
     /// `pkcs8` must have more than 0 and less than 16 elements.

--- a/oxish-proto/src/host_keys.rs
+++ b/oxish-proto/src/host_keys.rs
@@ -49,7 +49,7 @@ impl HostKeys {
     /// Create a new set of host keys from the given PKCS#8 private keys
     ///
     /// `pkcs8` must have more than 0 and less than 16 elements.
-    pub fn new(
+    fn new(
         pkcs8: impl Iterator<Item = Zeroizing<Vec<u8>>>,
         provider: &dyn CryptoProvider,
     ) -> Result<Self, ProtoError> {
@@ -68,6 +68,23 @@ impl HostKeys {
         }
 
         Ok(Self(keys))
+    }
+
+    // from OpenSSH v1 private key pem
+    #[doc(hidden)] // for testing
+    pub fn from_openssh_v1(pem: &str, provider: &dyn CryptoProvider) -> Result<Self, ProtoError> {
+        Self::new(OpenSshKeyV1::from_str(pem)?.keys.into_iter(), provider)
+    }
+
+    // The sole host key, for tests with a single-key [HostKeys]
+    #[doc(hidden)] // for testing
+    pub fn sole(&self) -> ServerHostKey<'_> {
+        // Cannot produce empty HostKey
+        let (pkcs8, key) = &self.0[0];
+        ServerHostKey {
+            pkcs8,
+            key: key.as_ref(),
+        }
     }
 
     /// Select the host key matching the negotiated algorithm
@@ -106,13 +123,6 @@ impl Encode for ServerHostKey<'_> {
     fn encode(&self, buf: &mut Vec<u8>) {
         let Self { pkcs8, key: _ } = self;
         pkcs8.encode(buf);
-    }
-}
-
-#[doc(hidden)] // for testing
-impl<'a> From<(&'a Zeroizing<Vec<u8>>, &'a dyn SigningKey)> for ServerHostKey<'a> {
-    fn from((pkcs8, key): (&'a Zeroizing<Vec<u8>>, &'a dyn SigningKey)) -> Self {
-        Self { pkcs8, key }
     }
 }
 

--- a/oxish-proto/src/key_exchange.rs
+++ b/oxish-proto/src/key_exchange.rs
@@ -624,7 +624,7 @@ impl Encode for TaggedSignature<'_> {
 ///
 /// Leading zero bytes are stripped, and a single zero byte is prepended when the
 /// most significant bit is set so the value is interpreted as positive.
-fn encode_mpint(value: &[u8], buf: &mut Vec<u8>) {
+pub(crate) fn encode_mpint(value: &[u8], buf: &mut Vec<u8>) {
     let trimmed = match value.iter().position(|&b| b != 0) {
         Some(first) => &value[first..],
         None => &[],

--- a/oxish-proto/src/key_exchange.rs
+++ b/oxish-proto/src/key_exchange.rs
@@ -620,7 +620,7 @@ impl Encode for TaggedSignature<'_> {
 ///
 /// Leading zero bytes are stripped, and a single zero byte is prepended when the
 /// most significant bit is set so the value is interpreted as positive.
-fn encode_mpint(value: &[u8], buf: &mut Vec<u8>) {
+pub(crate) fn encode_mpint(value: &[u8], buf: &mut Vec<u8>) {
     let trimmed = match value.iter().position(|&b| b != 0) {
         Some(first) => &value[first..],
         None => &[],

--- a/oxish-proto/src/lib.rs
+++ b/oxish-proto/src/lib.rs
@@ -25,6 +25,7 @@ pub mod key_exchange;
 /// Named algorithms, services and methods, and name-list encoding (RFC 4251 section 5)
 pub mod named;
 use named::PublicKeyAlgorithm;
+pub mod openssh;
 
 /// Protocol version exchange identification string
 ///

--- a/oxish-proto/src/openssh.rs
+++ b/oxish-proto/src/openssh.rs
@@ -1,0 +1,92 @@
+//! Encode Signingkey to OpenSSH v1 private key format
+
+use data_encoding::BASE64;
+use zeroize::Zeroizing;
+
+use crate::{
+    Encode, ProtoError, PublicKeyAlgorithm, crypto::SigningKey, key_exchange::encode_mpint,
+};
+
+/// Encode SigningKey as an unencrypted OpenSSH v1 private key file
+pub fn encode(key: &dyn SigningKey) -> Result<Zeroizing<String>, ProtoError> {
+    /// Block size of the `none` cipher
+    const BLOCK_SIZE: usize = 8;
+    /// Check value, written twice at the head of the private section
+    ///
+    /// OpenSSH compares the two copies after decryption to detect a
+    /// wrong passphrase; the value itself is not meaningful. This is
+    /// ASCII "SSH1". If encryption is ever supported, generate this
+    /// randomly instead, to avoid placing known plaintext at the
+    /// start of the encrypted blob.
+    const CHECK: u32 = 0x5353_4831;
+
+    let pubkey = key.public_key();
+    let Ok(seckey) = key.private_key() else {
+        return Err(ProtoError::InvalidHostKey("key cannot be serialized"));
+    };
+
+    let mut private = Zeroizing::new(Vec::with_capacity(512));
+    CHECK.encode(&mut private);
+    CHECK.encode(&mut private);
+
+    // The private key shares its leading fields with the public blob
+    let mut public = Vec::new();
+    match key.algorithm() {
+        PublicKeyAlgorithm::Ed25519 => {
+            if pubkey.len() != 32 || seckey.len() != 32 {
+                return Err(ProtoError::InvalidHostKey("invalid ed25519 key"));
+            }
+
+            b"ssh-ed25519".as_slice().encode(&mut public);
+            pubkey.encode(&mut public);
+            private.extend_from_slice(&public);
+
+            64u32.encode(&mut private);
+            private.extend_from_slice(&seckey);
+            private.extend_from_slice(pubkey);
+        }
+        PublicKeyAlgorithm::EcdsaSha2Nistp256 => {
+            b"ecdsa-sha2-nistp256".as_slice().encode(&mut public);
+            b"nistp256".as_slice().encode(&mut public);
+            pubkey.encode(&mut public);
+            private.extend_from_slice(&public);
+
+            encode_mpint(&seckey, &mut private);
+        }
+        PublicKeyAlgorithm::Unknown(_) => {
+            return Err(ProtoError::InvalidHostKey("unsupported key type"));
+        }
+    }
+
+    b"".as_slice().encode(&mut private); // comment
+
+    let padding = private.len().next_multiple_of(BLOCK_SIZE) - private.len();
+    for i in 0..padding {
+        private.push((i + 1) as u8);
+    }
+
+    let mut blob = Zeroizing::new(Vec::with_capacity(private.len() + public.len() + 64));
+    blob.extend_from_slice(b"openssh-key-v1\0");
+    b"none".as_slice().encode(&mut blob); // ciphername
+    b"none".as_slice().encode(&mut blob); // kdfname
+    b"".as_slice().encode(&mut blob); // kdfoptions
+    1u32.encode(&mut blob); // number of keys
+    public.as_slice().encode(&mut blob);
+    private.as_slice().encode(&mut blob);
+
+    let base64 = Zeroizing::new(BASE64.encode(&blob));
+    let mut out = Zeroizing::new(String::with_capacity(base64.len() + 128));
+
+    out.push_str("-----BEGIN OPENSSH PRIVATE KEY-----\n");
+    let mut rest = base64.as_str();
+    while !rest.is_empty() {
+        // base64 is ASCII, so splitting on a byte index is safe
+        let (line, tail) = rest.split_at(rest.len().min(70));
+        out.push_str(line);
+        out.push('\n');
+        rest = tail;
+    }
+    out.push_str("-----END OPENSSH PRIVATE KEY-----\n");
+
+    Ok(out)
+}

--- a/oxish-proto/src/openssh.rs
+++ b/oxish-proto/src/openssh.rs
@@ -4,11 +4,22 @@ use data_encoding::BASE64;
 use zeroize::Zeroizing;
 
 use crate::{
-    Encode, ProtoError, PublicKeyAlgorithm, crypto::SigningKey, key_exchange::encode_mpint,
+    Encode, ProtoError, PublicKeyAlgorithm,
+    crypto::{CryptoProvider, GeneratedKey},
+    key_exchange::encode_mpint,
 };
 
+/// Generate fresh signing key and return it with OpenSSH v1 pem
+pub fn generate(
+    algorithm: &PublicKeyAlgorithm<'_>,
+    provider: &dyn CryptoProvider,
+) -> Result<Zeroizing<String>, ProtoError> {
+    let gkey = provider.generate_signing_key(algorithm)?;
+    encode(&gkey)
+}
+
 /// Encode SigningKey as an unencrypted OpenSSH v1 private key file
-pub fn encode(key: &dyn SigningKey, seckey: &[u8]) -> Result<Zeroizing<String>, ProtoError> {
+fn encode(gkey: &GeneratedKey) -> Result<Zeroizing<String>, ProtoError> {
     /// Block size of the `none` cipher
     const BLOCK_SIZE: usize = 8;
     /// Check value, written twice at the head of the private section
@@ -20,7 +31,9 @@ pub fn encode(key: &dyn SigningKey, seckey: &[u8]) -> Result<Zeroizing<String>, 
     /// start of the encrypted blob.
     const CHECK: u32 = 0x5353_4831;
 
+    let key = &gkey.0;
     let pubkey = key.public_key();
+    let seckey = &gkey.1;
 
     let mut private = Zeroizing::new(Vec::with_capacity(512));
     CHECK.encode(&mut private);
@@ -39,7 +52,7 @@ pub fn encode(key: &dyn SigningKey, seckey: &[u8]) -> Result<Zeroizing<String>, 
             private.extend_from_slice(&public);
 
             64u32.encode(&mut private);
-            private.extend_from_slice(&seckey);
+            private.extend_from_slice(seckey);
             private.extend_from_slice(pubkey);
         }
         PublicKeyAlgorithm::EcdsaSha2Nistp256 => {
@@ -48,7 +61,7 @@ pub fn encode(key: &dyn SigningKey, seckey: &[u8]) -> Result<Zeroizing<String>, 
             pubkey.encode(&mut public);
             private.extend_from_slice(&public);
 
-            encode_mpint(&seckey, &mut private);
+            encode_mpint(seckey, &mut private);
         }
         PublicKeyAlgorithm::Unknown(_) => {
             return Err(ProtoError::InvalidHostKey("unsupported key type"));

--- a/oxish-proto/src/openssh.rs
+++ b/oxish-proto/src/openssh.rs
@@ -1,0 +1,89 @@
+//! Encode Signingkey to OpenSSH v1 private key format
+
+use data_encoding::BASE64;
+use zeroize::Zeroizing;
+
+use crate::{
+    Encode, ProtoError, PublicKeyAlgorithm, crypto::SigningKey, key_exchange::encode_mpint,
+};
+
+/// Encode SigningKey as an unencrypted OpenSSH v1 private key file
+pub fn encode(key: &dyn SigningKey, seckey: &[u8]) -> Result<Zeroizing<String>, ProtoError> {
+    /// Block size of the `none` cipher
+    const BLOCK_SIZE: usize = 8;
+    /// Check value, written twice at the head of the private section
+    ///
+    /// OpenSSH compares the two copies after decryption to detect a
+    /// wrong passphrase; the value itself is not meaningful. This is
+    /// ASCII "SSH1". If encryption is ever supported, generate this
+    /// randomly instead, to avoid placing known plaintext at the
+    /// start of the encrypted blob.
+    const CHECK: u32 = 0x5353_4831;
+
+    let pubkey = key.public_key();
+
+    let mut private = Zeroizing::new(Vec::with_capacity(512));
+    CHECK.encode(&mut private);
+    CHECK.encode(&mut private);
+
+    // The private key shares its leading fields with the public blob
+    let mut public = Vec::new();
+    match key.algorithm() {
+        PublicKeyAlgorithm::Ed25519 => {
+            if pubkey.len() != 32 || seckey.len() != 32 {
+                return Err(ProtoError::InvalidHostKey("invalid ed25519 key"));
+            }
+
+            b"ssh-ed25519".as_slice().encode(&mut public);
+            pubkey.encode(&mut public);
+            private.extend_from_slice(&public);
+
+            64u32.encode(&mut private);
+            private.extend_from_slice(&seckey);
+            private.extend_from_slice(pubkey);
+        }
+        PublicKeyAlgorithm::EcdsaSha2Nistp256 => {
+            b"ecdsa-sha2-nistp256".as_slice().encode(&mut public);
+            b"nistp256".as_slice().encode(&mut public);
+            pubkey.encode(&mut public);
+            private.extend_from_slice(&public);
+
+            encode_mpint(&seckey, &mut private);
+        }
+        PublicKeyAlgorithm::Unknown(_) => {
+            return Err(ProtoError::InvalidHostKey("unsupported key type"));
+        }
+    }
+
+    b"".as_slice().encode(&mut private); // comment
+
+    let padding = private.len().next_multiple_of(BLOCK_SIZE) - private.len();
+    for i in 0..padding {
+        private.push((i + 1) as u8);
+    }
+
+    let mut blob = Zeroizing::new(Vec::with_capacity(private.len() + public.len() + 64));
+    blob.extend_from_slice(b"openssh-key-v1\0");
+    b"none".as_slice().encode(&mut blob); // ciphername
+    b"none".as_slice().encode(&mut blob); // kdfname
+    b"".as_slice().encode(&mut blob); // kdfoptions
+    1u32.encode(&mut blob); // number of keys
+    public.as_slice().encode(&mut blob);
+    private.as_slice().encode(&mut blob);
+
+    let base64 = Zeroizing::new(BASE64.encode(&blob));
+    let mut out = Zeroizing::new(String::with_capacity(base64.len() + 128));
+
+    out.push_str("-----BEGIN OPENSSH PRIVATE KEY-----\n");
+    let mut rest = base64.as_str();
+    while !rest.is_empty() {
+        // base64 is ASCII, so splitting on a byte index is safe
+        let (line, tail) = rest.split_at(rest.len().min(70));
+        out.push_str(line);
+        out.push('\n');
+        rest = tail;
+    }
+    out.push_str("-----END OPENSSH PRIVATE KEY-----\n");
+
+    Ok(out)
+}

--- a/oxish/src/bin/oxish-server.rs
+++ b/oxish/src/bin/oxish-server.rs
@@ -57,11 +57,10 @@ async fn main() -> anyhow::Result<()> {
             }
             Err(error) => {
                 eprintln!("failed to load host keys from /etc/ssh: {error}");
-                let pkcs8 = Zeroizing::new(fs::read(&args.host_key_file).context(format!(
-                    "failed to read host key from {}",
-                    args.host_key_file
-                ))?);
-                HostKeys::new([pkcs8].into_iter(), provider)?
+                let pem = Zeroizing::new(fs::read_to_string(&args.host_key_file).context(
+                    format!("failed to read host key from {}", args.host_key_file),
+                )?);
+                HostKeys::from_openssh_v1(&pem, provider)?
             }
         }
     };

--- a/oxish/src/bin/oxish-server.rs
+++ b/oxish/src/bin/oxish-server.rs
@@ -32,15 +32,15 @@ async fn main() -> anyhow::Result<()> {
     let host_keys = if args.generate_host_key {
         match File::create_new(&args.host_key_file) {
             Ok(mut host_key_file) => {
-                let Ok((_, pkcs8)) = provider.generate_signing_key(&args.host_key_type) else {
+                let Ok((key, pkcs8)) = provider.generate_signing_key(&args.host_key_type) else {
                     anyhow::bail!("failed to generate host key");
                 };
+                let _pkcs8 = Zeroizing::new(pkcs8);
 
                 // FIXME ensure the host key is only readable by the ssh server user
-                let pkcs8 = Zeroizing::new(pkcs8);
-                let result = host_key_file.write_all(&pkcs8);
-                result?;
+                let pem = proto::openssh::encode(&*key)?;
 
+                host_key_file.write_all(pem.as_bytes())?;
                 eprintln!("generated host key at {}", args.host_key_file);
                 return Ok(());
             }

--- a/oxish/src/bin/oxish-server.rs
+++ b/oxish/src/bin/oxish-server.rs
@@ -19,7 +19,6 @@ use proto::{
 };
 use tokio::net::TcpListener;
 use tracing::info;
-use zeroize::Zeroizing;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -33,13 +32,12 @@ async fn main() -> anyhow::Result<()> {
     if let Some(path) = &args.generate_host_key {
         return match File::create_new(path) {
             Ok(mut host_key_file) => {
-                let Ok((_, pkcs8)) = provider.generate_signing_key(&args.host_key_type) else {
+                let Ok(pem) = proto::openssh::generate(&args.host_key_type, provider) else {
                     anyhow::bail!("failed to generate host key");
                 };
 
                 // FIXME ensure the host key is only readable by the ssh server user
-                let pkcs8 = Zeroizing::new(pkcs8);
-                let result = host_key_file.write_all(&pkcs8);
+                let result = host_key_file.write_all(pem.as_bytes());
                 result?;
 
                 eprintln!("generated host key at {}", path.display());

--- a/oxish/src/tests.rs
+++ b/oxish/src/tests.rs
@@ -1,6 +1,7 @@
 use core::{net::Ipv4Addr, net::SocketAddr, time::Duration};
 use std::{
     env, fs,
+    os::unix::fs::PermissionsExt,
     panic::resume_unwind,
     path::Path,
     path::PathBuf,
@@ -27,6 +28,45 @@ use crate::{
     authentication::{SingleUser, User},
     server::Server,
 };
+
+/// Check our generated OpenSSH private key accepted by `ssh-keygen -y -f`
+#[tokio::test]
+async fn openssh_keygen_agrees() {
+    let providers = [
+        #[cfg(any(feature = "aws-lc", feature = "aws-lc-fips"))]
+        aws_lc::DEFAULT_PROVIDER,
+        #[cfg(feature = "graviola")]
+        graviola::DEFAULT_PROVIDER,
+    ];
+
+    for provider in providers {
+        for (algorithm, name) in [
+            (PublicKeyAlgorithm::Ed25519, "ssh-ed25519"),
+            (PublicKeyAlgorithm::EcdsaSha2Nistp256, "ecdsa-sha2-nistp256"),
+        ] {
+            let pem = openssh::generate(&algorithm, provider).unwrap();
+
+            let dir = TempDir::new().unwrap();
+            let path = dir.path().join("key");
+            fs::write(&path, pem.as_bytes()).unwrap();
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+
+            let output = Command::new("ssh-keygen")
+                .arg("-y")
+                .arg("-f")
+                .arg(&path)
+                .output()
+                .await
+                .context("failed to run ssh-keygen")
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "ssh-keygen rejected our {name} key: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+}
 
 /// Exercise a full handshake and session against the aws-lc-rs provider
 #[cfg(feature = "aws-lc")]

--- a/oxish/src/tests.rs
+++ b/oxish/src/tests.rs
@@ -10,17 +10,17 @@ use std::{
 
 use anyhow::Context;
 use proto::{
-    Decoded, Encode, HostKeys, ServerHostKey,
+    Decoded, Encode, HostKeys,
     auth::AuthorizedKey,
     crypto::{CryptoProvider, Digest, KeySourceSide},
     key_exchange::Identities,
     named::{EncryptionAlgorithm, PublicKeyAlgorithm},
+    openssh,
 };
 use tempfile::TempDir;
 use tokio::{
     io::AsyncWriteExt, net::TcpListener, process::Command, task::JoinHandle, time::timeout,
 };
-use zeroize::Zeroizing;
 
 use crate::{
     Config, SessionState, SideState, UserStore, Username,
@@ -224,14 +224,14 @@ async fn setup(
     provider: &'static dyn CryptoProvider,
 ) -> anyhow::Result<(TempDir, CliClient, JoinHandle<anyhow::Result<()>>)> {
     let (key_dir, store) = store(algorithm, provider).await?;
-    let (_, pkcs8) = provider.generate_signing_key(algorithm)?;
+    let pem = openssh::generate(algorithm, provider)?;
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await?;
     let addr = listener.local_addr()?;
     let client = CliClient::new(addr, &key_dir.path().join("key"));
 
     let server = Server::new(
         store,
-        HostKeys::new([Zeroizing::new(pkcs8)].into_iter(), provider)?,
+        HostKeys::from_openssh_v1(&pem, provider)?,
         session_binary().await?,
         provider,
     )?;
@@ -406,11 +406,10 @@ async fn verify_keys() {
 #[test]
 fn session_state_round_trip() {
     use crate::DEFAULT_PROVIDER;
-    let (key, pkcs8) = DEFAULT_PROVIDER
-        .generate_signing_key(&PublicKeyAlgorithm::Ed25519)
+    let pem = openssh::generate(&PublicKeyAlgorithm::Ed25519, DEFAULT_PROVIDER)
         .expect("failed to generate signing key");
-    let pkcs8 = Zeroizing::new(pkcs8);
-    let host_key = ServerHostKey::from((&pkcs8, &*key));
+    let host_keys = HostKeys::from_openssh_v1(&pem, DEFAULT_PROVIDER).unwrap();
+    let host_key = host_keys.sole();
 
     let state = SessionState {
         addr: SocketAddr::from(([192, 0, 2, 7], 22022)),


### PR DESCRIPTION
Closes: https://github.com/djc/oxish/issues/267

This PR changes:
1. `--host-key-file` to accept OpenSSH format  instead `PKCS#8`
2. `--generate-host-key` to generate OpenSSH format  instead `PKCS#8`

(2) requires adding `proto::openssh::encode()` to encode OpenSSH format from trait `crypto::SigningKey`.

Encoding OpenSSH format requires private key, so it is added on `SigningKey` also. Since key generation is not necessary for all SSH daemons, I have configured backends that do not implement private_key() to return an error. This prevents breaking change too.

The reason I did not use the existing `OpenSshKeyV1` struct, is that it contains already encoded `PKCS#8`, and with it, encoding requires re-parse and re-encoding, while we have `SigningKey` handle when generation.

---

Some concerns left for later:
- `HostKeys::new()` is no longer needed, so it could be made private. It's still used in a test, though, so it would need to be changed as well.
- The `pkcs8` in return value of `provider::generate_signing_key()` is no longer used. It's used in tests too, so I left it for now. But if it's simply discarded without zeroizing, it may leave the generated private key in memory.
- Adding a new `CryptoError` variant is a breaking change, so `SigningKey::private_key()` returns `Err(CryptoError::Unspecified)` on error for now. If we're okay with it, something like `KeyNotExportable` would be more helpful for debugging.

