### PR TITLE
replacing platform dependent `st_uid()` and `st_mode()` with `mode()` and `uid()` from `std::os::unix`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,16 @@ jobs:
       - run: cargo check -p oxish --no-default-features --features aws-lc
       - run: cargo test --features graviola,aws-lc -- --include-ignored
 
+  freebsd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: x86_64-unknown-freebsd
+      - run: cargo check --target x86_64-unknown-freebsd -p oxish
+
   msrv:
     runs-on: ubuntu-latest
     steps:

--- a/oxish/src/authentication.rs
+++ b/oxish/src/authentication.rs
@@ -5,11 +5,7 @@ use core::{
     ops::{ControlFlow, Deref},
     time::Duration,
 };
-#[cfg(target_vendor = "apple")]
-use std::os::darwin::fs::MetadataExt;
-#[cfg(target_os = "linux")]
-use std::os::linux::fs::MetadataExt;
-#[cfg(all(unix, not(target_vendor = "apple"), not(target_os = "linux")))]
+#[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 use std::{
     borrow::Cow,
@@ -724,7 +720,7 @@ fn check_permissions(file: &File, uid: u32, level: &str) -> ControlFlow<()> {
         }
     };
 
-    match meta.st_mode() & 0o022 == 0 && (meta.st_uid() == 0 || meta.st_uid() == uid) {
+    match meta.mode() & 0o022 == 0 && (meta.uid() == 0 || meta.uid() == uid) {
         true => ControlFlow::Continue(()),
         false => ControlFlow::Break(()),
     }


### PR DESCRIPTION
fixes #270 