### PR TITLE
fix(fuzz): repair decode target and build it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,18 @@ jobs:
         env:
           RUSTDOCFLAGS: -Dwarnings
 
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # cargo-fuzz needs nightly for the sanitizer instrumentation
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
+      # the prebuilt cargo-fuzz defaults to a musl target, which sanitizers can't use
+      - run: cargo fuzz build --target x86_64-unknown-linux-gnu
+
   coverage:
     runs-on: ubuntu-26.04
     steps:

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,8 +93,10 @@ dependencies = [
 name = "oxish-proto"
 version = "0.1.0"
 dependencies = [
+ "data-encoding",
  "thiserror",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -194,3 +202,9 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oxish-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/fuzz_targets/decode.rs
+++ b/fuzz/fuzz_targets/decode.rs
@@ -2,9 +2,10 @@
 
 use libfuzzer_sys::fuzz_target;
 use proto::{
-    ChannelClose, ChannelData, ChannelEof, ChannelOpen, ChannelRequest, Completion, Disconnect,
-    EcdhKeyExchangeInit, KeyExchangeInit, MessageType, NewKeys, ReadState,
-    ServiceRequest, UserAuthRequest,
+    Completion, Disconnect, MessageType, ReadState,
+    auth::{ServiceRequest, UserAuthRequest},
+    channels::{ChannelClose, ChannelData, ChannelEof, ChannelOpen, ChannelRequest},
+    key_exchange::{EcdhKeyExchangeInit, KeyExchangeInit, NewKeys},
 };
 
 fuzz_target!(|data: &[u8]| {


### PR DESCRIPTION
closes #273 

The fuzz crate stopped building after 97e3713 moved the message types into submodules. 

CI didn't catch it because fuzz/ declares its own workspace. 
So, `cargo check --all-targets` and `cargo clippy --all-targets` never build it.

- decode.rs: import the moved types from auth, channels and key_exchange
- fuzz/Cargo.lock: add data-encoding and zeroize, now dependencies of oxish-proto
- fuzz/Cargo.toml: edition 2021 -> 2024, to match the workspace
- ci.yml: new fuzz job running `cargo fuzz build` on nightly, so this can't silently fail again

CI/ coverage (pull_request) fails on `Token length: 0`,
CODECOV secrets aren't exposed to the PRs runs from forks. 🥺