### PR TITLE
Hardcode default hostkey paths

### DIFF
--- a/oxish-proto/src/host_keys.rs
+++ b/oxish-proto/src/host_keys.rs
@@ -1,7 +1,7 @@
 use core::str::{self, FromStr};
 use std::{fs, path::Path};
 
-use tracing::{debug, warn};
+use tracing::warn;
 use zeroize::Zeroizing;
 
 use crate::{
@@ -16,77 +16,34 @@ use crate::{
 pub struct HostKeys(Vec<(Zeroizing<Vec<u8>>, Box<dyn SigningKey>)>);
 
 impl HostKeys {
-    /// Find host keys in the given directory
+    /// Create host keys from a list of OpenSSH-format private key files
     ///
-    /// Scans `dir` (usually `/etc/ssh`) for files named `ssh_host_*_key` containing
-    /// unencrypted private keys in the OpenSSH key format. Keys using algorithms not
-    /// known to this implementation are skipped.
-    pub fn from_dir(dir: &Path, provider: &dyn CryptoProvider) -> Result<Self, ProtoError> {
+    /// Files that cannot be read or parsed are skipped. Only supports
+    /// unencrypted keys for now.
+    pub fn from_files(
+        paths: impl Iterator<Item = impl AsRef<Path>>,
+        provider: &dyn CryptoProvider,
+    ) -> Result<Self, ProtoError> {
         let mut keys = Vec::new();
-        let mut error = None;
-        for entry in dir.read_dir()? {
-            let Ok(entry) = entry else {
-                debug!("skipping unreadable entry in host key directory");
-                continue;
-            };
+        for path in paths {
+            let path = path.as_ref();
 
-            let Ok(ty) = entry.file_type() else {
-                debug!(name = ?entry.file_name(), "skipping unreadable entry in host key directory");
-                continue;
-            };
-
-            if !ty.is_file() {
-                continue;
-            }
-
-            let name = entry.file_name();
-            let Some(name) = name.to_str() else {
-                continue;
-            };
-
-            if !name.starts_with("ssh_host_") || !name.ends_with("_key") {
-                continue;
-            }
-
-            let pem = match fs::read_to_string(entry.path()) {
+            // FIXME avoid read_to_string() leaving key material in reallocated buffers
+            let pem = match fs::read_to_string(path) {
                 Ok(pem) => Zeroizing::new(pem),
-                Err(e) => {
-                    debug!(name, error = %e, "skipping unreadable host key file");
-                    error = Some((ProtoError::Io(e), entry.path().to_owned()));
+                Err(error) => {
+                    warn!(?path, %error, "skipping unreadable host key file");
                     continue;
                 }
             };
 
-            let decoded = match OpenSshKeyV1::from_str(&pem) {
-                Ok(keys) => keys,
-                Err(e) => {
-                    debug!(name, "skipping host key file with invalid format");
-                    error = Some((e, entry.path().to_owned()));
-                    continue;
-                }
-            };
-
-            for pkcs8 in decoded.keys {
-                let signing_key = provider.signing_key_from_pkcs8(&pkcs8)?;
-                keys.push((pkcs8, signing_key));
-            }
-
-            if keys.len() >= Self::MAX_KEYS {
-                return Err(ProtoError::TooManyHostKeys);
+            match OpenSshKeyV1::from_str(&pem) {
+                Ok(decoded) => keys.extend(decoded.keys),
+                Err(error) => warn!(?path, %error, "skipping host key file with invalid format"),
             }
         }
 
-        if keys.is_empty() {
-            return Err(match error {
-                Some((error, path)) => {
-                    warn!(?path, %error, "no valid host keys found in directory");
-                    error
-                }
-                None => ProtoError::NoHostKeys,
-            });
-        }
-
-        Ok(Self(keys))
+        Self::new(keys.into_iter(), provider)
     }
 
     /// Create a new set of host keys from the given PKCS#8 private keys

--- a/oxish-proto/src/host_keys.rs
+++ b/oxish-proto/src/host_keys.rs
@@ -98,12 +98,12 @@ impl HostKeys {
     ) -> Result<Self, ProtoError> {
         let mut keys = Vec::new();
         for pkcs8 in pkcs8 {
+            let signing_key = provider.signing_key_from_pkcs8(&pkcs8)?;
+            keys.push((pkcs8, signing_key));
+
             if keys.len() >= Self::MAX_KEYS {
                 return Err(ProtoError::TooManyHostKeys);
             }
-
-            let signing_key = provider.signing_key_from_pkcs8(&pkcs8)?;
-            keys.push((pkcs8, signing_key));
         }
 
         if keys.is_empty() {

--- a/oxish/src/bin/oxish-server.rs
+++ b/oxish/src/bin/oxish-server.rs
@@ -1,13 +1,12 @@
 use core::net::{Ipv4Addr, SocketAddr};
 use std::{
     env,
-    fs::{self, File},
+    fs::File,
     io::{self, Write},
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::Arc,
 };
 
-use anyhow::Context;
 #[cfg(debug_assertions)]
 use clap::ArgAction;
 use clap::Parser;
@@ -21,6 +20,11 @@ use proto::{
 use tokio::net::TcpListener;
 use tracing::info;
 use zeroize::Zeroizing;
+
+const DEFAULT_HOST_KEY_FILES: &[&str] = &[
+    "/etc/ssh/ssh_host_ed25519_key",
+    "/etc/ssh/ssh_host_ecdsa_key",
+];
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -54,22 +58,11 @@ async fn main() -> anyhow::Result<()> {
         };
     }
 
-    let host_keys = {
-        match HostKeys::from_dir(Path::new("/etc/ssh"), provider) {
-            Ok(host_keys) => {
-                info!(len = host_keys.len(), "loaded host keys from /etc/ssh");
-                host_keys
-            }
-            Err(error) => {
-                eprintln!("failed to load host keys from /etc/ssh: {error}");
-                let pkcs8 = Zeroizing::new(fs::read(&args.host_key_file).context(format!(
-                    "failed to read host key from {}",
-                    args.host_key_file
-                ))?);
-                HostKeys::new([pkcs8].into_iter(), provider)?
-            }
-        }
+    let host_keys = match HostKeys::from_files(args.host_key_file.into_iter(), provider) {
+        Ok(host_keys) => host_keys,
+        Err(e) => anyhow::bail!("{e} (try RUST_LOG=warn for more information)"),
     };
+    info!(len = host_keys.len(), "loaded host keys");
 
     let session_bin = match args.session_bin {
         Some(path) => path,
@@ -134,8 +127,8 @@ async fn main() -> anyhow::Result<()> {
 struct Args {
     #[clap(short, long)]
     port: Option<u16>,
-    #[clap(long, default_value = "ssh_host_ed25519_key")]
-    host_key_file: String,
+    #[clap(long, default_values = DEFAULT_HOST_KEY_FILES)]
+    host_key_file: Vec<PathBuf>,
     #[clap(long)]
     generate_host_key: Option<PathBuf>,
     #[clap(long, value_parser = host_key_type, default_value = "ssh-ed25519")]

--- a/oxish/src/bin/oxish-server.rs
+++ b/oxish/src/bin/oxish-server.rs
@@ -30,8 +30,9 @@ async fn main() -> anyhow::Result<()> {
 
     let provider = DEFAULT_PROVIDER;
     let args = Args::parse();
-    let host_keys = if args.generate_host_key {
-        match File::create_new(&args.host_key_file) {
+
+    if let Some(path) = &args.generate_host_key {
+        return match File::create_new(path) {
             Ok(mut host_key_file) => {
                 let Ok((_, pkcs8)) = provider.generate_signing_key(&args.host_key_type) else {
                     anyhow::bail!("failed to generate host key");
@@ -42,15 +43,18 @@ async fn main() -> anyhow::Result<()> {
                 let result = host_key_file.write_all(&pkcs8);
                 result?;
 
-                eprintln!("generated host key at {}", args.host_key_file);
-                return Ok(());
+                eprintln!("generated host key at {}", path.display());
+                Ok(())
             }
-            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
-                anyhow::bail!("host key file `{}` already exists", args.host_key_file);
-            }
-            Err(err) => return Err(err.into()),
-        }
-    } else {
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => Err(anyhow::anyhow!(
+                "host key file `{}` already exists",
+                path.display()
+            )),
+            Err(err) => Err(err.into()),
+        };
+    }
+
+    let host_keys = {
         match HostKeys::from_dir(Path::new("/etc/ssh"), provider) {
             Ok(host_keys) => {
                 info!(len = host_keys.len(), "loaded host keys from /etc/ssh");
@@ -133,7 +137,7 @@ struct Args {
     #[clap(long, default_value = "ssh_host_ed25519_key")]
     host_key_file: String,
     #[clap(long)]
-    generate_host_key: bool,
+    generate_host_key: Option<PathBuf>,
     #[clap(long, value_parser = host_key_type, default_value = "ssh-ed25519")]
     host_key_type: PublicKeyAlgorithm<'static>,
     /// Path to the `oxish-session` binary (defaults to a sibling of this executable)

--- a/oxish/src/tests.rs
+++ b/oxish/src/tests.rs
@@ -305,35 +305,40 @@ impl CliClient {
 
 #[cfg(feature = "aws-lc")]
 #[tokio::test]
-async fn host_keys_from_dir_aws_lc() {
-    host_keys_from_dir(aws_lc::DEFAULT_PROVIDER).await.unwrap();
-}
-
-#[cfg(feature = "graviola")]
-#[tokio::test]
-async fn host_keys_from_dir_graviola() {
-    host_keys_from_dir(graviola::DEFAULT_PROVIDER)
+async fn host_keys_from_files_aws_lc() {
+    host_keys_from_files(aws_lc::DEFAULT_PROVIDER)
         .await
         .unwrap();
 }
 
-async fn host_keys_from_dir(provider: &'static dyn CryptoProvider) -> anyhow::Result<()> {
+#[cfg(feature = "graviola")]
+#[tokio::test]
+async fn host_keys_from_files_graviola() {
+    host_keys_from_files(graviola::DEFAULT_PROVIDER)
+        .await
+        .unwrap();
+}
+
+async fn host_keys_from_files(provider: &'static dyn CryptoProvider) -> anyhow::Result<()> {
     let dir = TempDir::new()?;
+    let mut paths = Vec::new();
     for key_type in ["ed25519", "ecdsa", "rsa"] {
+        let path = dir.path().join(format!("ssh_host_{key_type}_key"));
         let status = Command::new("ssh-keygen")
             .arg("-q")
             .args(["-t", key_type])
             .args(["-N", ""])
             .args(["-C", "oxish-e2e"])
             .arg("-f")
-            .arg(dir.path().join(format!("ssh_host_{key_type}_key")))
+            .arg(&path)
             .status()
             .await
             .context("failed to run ssh-keygen")?;
         assert!(status.success(), "ssh-keygen failed");
+        paths.push(path);
     }
 
-    let host_keys = HostKeys::from_dir(dir.path(), provider)?;
+    let host_keys = HostKeys::from_files(paths.iter(), provider)?;
     let mut algorithms = Vec::new();
     for algorithm in host_keys.algorithms() {
         algorithms.push(algorithm);


### PR DESCRIPTION
On the base dir constant: keeping it means joining `/etc/ssh` and `ssh_host_ed25519_key` at runtime (`concat!` only takes string literals), which rules out clap's generated `[default: ...]` documentation. The split also assumes only the directory differs per OS -- with a single list of full paths, a platform that differs in either respect is one place to change rather than two constants.

So I hardcoded the full list instead. For Windows this is no different from swapping `DEFAULT_HOST_KEY_DIR`.

I think this reads better, but it does go against what we agreed on, so happy to switch to the runtime-join version if you'd rather have that.

`HostKeys::from_dir()` has no callers left. If you're happy with this change, I'll remove it in a follow-up and rework its tests to cover `from_openssh_v1()` instead.

Closes: #289 
Related: #267 #268  